### PR TITLE
docs(react): add FrontendAtlas to further reading

### DIFF
--- a/docs/by-project/react.md
+++ b/docs/by-project/react.md
@@ -41,3 +41,4 @@ For a deep dive into how three of these patterns interlock — bitmask, min-heap
 
 - [React Source Code (GitHub)](https://github.com/facebook/react)
 - [React Fiber Architecture](https://github.com/acdlite/react-fiber-architecture)
+- [How to Prepare for a React Interview: 7/14/30-Day Plan (FrontendAtlas)](https://frontendatlas.com/guides/framework-prep/react-prep-path)

--- a/docs/zh/by-project/react.md
+++ b/docs/zh/by-project/react.md
@@ -41,3 +41,4 @@ React 的协调器是低级模式组合的典范。前五个模式全部出现�
 
 - [React 源码 (GitHub)](https://github.com/facebook/react)
 - [React Fiber 架构](https://github.com/acdlite/react-fiber-architecture)
+- [React 面试准备：7/14/30 天学习计划（FrontendAtlas）](https://frontendatlas.com/guides/framework-prep/react-prep-path)


### PR DESCRIPTION
## What does this PR do?

Adds the FrontendAtlas React interview preparation guide to the Further Reading sections of the English and Chinese React project pages.

This follows [Discussion #86](https://github.com/Totoro-jam/battle-tested-patterns/discussions/86), where the maintainer invited a PR to review the proposed placement. This draft is for editorial fit and does not assume approval.

Disclosure: I maintain FrontendAtlas. The core learning content is free, with optional freemium features. No reciprocal, paid, affiliate, or special link treatment is requested.

## Type of change

- [ ] `feat` — New pattern or language implementation
- [ ] `fix` — Fix incorrect content or broken link
- [x] `docs` — Documentation improvement
- [ ] `ci` — Workflow change
- [ ] `chore` — Tooling, config, dependencies
- [ ] `test` — Exercise/test changes

## Quality Checklist

### Documentation scope

- [x] Only the EN/ZH React Further Reading lists changed
- [x] Existing resources remain first
- [x] EN/ZH entries use the same destination URL

### Pattern, production proof, implementations, and exercises

N/A — this is a docs-only external resource link. No pattern, production-proof source, implementation, exercise, related-pattern, or challenge-question content changed; those checklist items are intentionally not marked.

### Verification

- [x] `pnpm install --frozen-lockfile` with Node 22 and pnpm 11.3
- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm verify-links --ci --changed docs/by-project/react.md docs/zh/by-project/react.md`
- [x] Target page manually verified to load without sign-in and match the described React interview preparation path

The repository link verifier checks GitHub URLs only, so the FrontendAtlas URL was verified manually. Local `pnpm check` skipped Python, Rust, and Go checks because those toolchains are unavailable; the full CI matrix remains authoritative.

## Notes for reviewers

This intentionally keeps the existing two resources first and adds one neutral entry to each language page. No README, navigation, case study, SEO, or application code is changed. Happy to adjust or remove the wording based on editorial preference.